### PR TITLE
Refactor Completer API

### DIFF
--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -568,11 +568,6 @@ export namespace CompletionHandler {
     documentation?: string;
 
     /**
-     * A number used to help sort a set of completion items.
-     */
-    score?: number;
-
-    /**
      * A string used to help filter a set of completion items.
      */
     filterText?: string;

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -16,6 +16,7 @@ import { Message, MessageLoop } from '@lumino/messaging';
 import { Signal } from '@lumino/signaling';
 
 import { Completer } from './widget';
+// import { ModelDB } from '@jupyterlab/observables/src';
 
 /**
  * A class added to editors that can host a completer.
@@ -398,14 +399,31 @@ export class CompletionHandler implements IDisposable {
     // Update the original request.
     model.original = state;
 
+    if (reply.items) {
+      model.setItems(reply.items);
+    }
+
     // Dedupe the matches.
     const matches: string[] = [];
     const matchSet = new Set(reply.matches || []);
 
+    const items: CompletionHandler.ICompletionItem[] = [];
+
     if (reply.matches) {
       matchSet.forEach(match => {
         matches.push(match);
+        let item: CompletionHandler.ICompletionItem = {
+          label: match,
+          range: { start: reply.start, end: reply.end },
+          icon: '',
+          resolve: () => {}
+        };
+        items.push(item);
       });
+    }
+
+    if (!reply.items && items.length > 0) {
+      model.setItems({ isIncomplete: false, items });
     }
 
     // Extract the optional type map. The current implementation uses
@@ -523,6 +541,8 @@ export namespace CompletionHandler {
      * Any metadata that accompanies the completion reply.
      */
     metadata: ReadonlyJSONObject;
+
+    items?: ICompletionItems;
   }
 
   /**

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -7,7 +7,12 @@ import { Text } from '@jupyterlab/coreutils';
 
 import { IDataConnector } from '@jupyterlab/statedb';
 
-import { ReadonlyJSONObject, JSONObject, JSONArray } from '@lumino/coreutils';
+import {
+  ReadonlyJSONObject,
+  JSONObject,
+  JSONArray,
+  PartialJSONObject
+} from '@lumino/coreutils';
 
 import { IDisposable } from '@lumino/disposable';
 
@@ -16,7 +21,6 @@ import { Message, MessageLoop } from '@lumino/messaging';
 import { Signal } from '@lumino/signaling';
 
 import { Completer } from './widget';
-// import { ModelDB } from '@jupyterlab/observables/src';
 
 /**
  * A class added to editors that can host a completer.
@@ -310,7 +314,6 @@ export class CompletionHandler implements IDisposable {
     if (start.column !== end.column || start.line !== end.line) {
       return;
     }
-
     // Dispatch the text change.
     model.handleTextChange(this.getState(editor, editor.getCursorPosition()));
   }
@@ -429,12 +432,11 @@ export class CompletionHandler implements IDisposable {
         let completionItem: CompletionHandler.ICompletionItem = {
           label: text,
           type: type,
-          range: { start: reply.start, end: reply.end },
-          icon: '',
-          resolve: () => {}
+          range: { start: reply.start, end: reply.end }
         };
         items.push(completionItem);
       });
+      model.isLegacy = true;
       model.setItems({ isIncomplete: false, items });
     }
 
@@ -495,25 +497,27 @@ export namespace CompletionHandler {
     connector: IDataConnector<IReply, void, IRequest>;
   }
 
-  export interface ICompletionItems {
+  export interface ICompletionItems extends PartialJSONObject {
     isIncomplete: boolean;
     items: Array<ICompletionItem>;
   }
 
-  export interface ICompletionItem {
+  export interface ICompletionItem extends PartialJSONObject {
     label: string;
     insertText?: string;
-    range: IRange;
+    range?: IRange;
     type?: string;
-    icon: string;
+    icon?: string;
     documentation?: string;
-    resolve(): void;
+    score?: number;
+    // TODO: This is not compatiable with lumino, try to find alternative.
+    // resolve?: () => void;
     filterText?: string;
     deprecated?: boolean;
     data?: any;
   }
 
-  export interface IRange {
+  export interface IRange extends PartialJSONObject {
     start: number;
     end: number;
   }

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -514,11 +514,16 @@ export namespace CompletionHandler {
   /**
    * Wrapper object for ICompletionItem.
    */
-  export interface ICompletionItems extends PartialJSONObject {
+  export interface ICompletionItems {
     /**
      * isIncomplete is true if this is a partial list of completion items.
      */
     isIncomplete: boolean;
+
+    /**
+     * Callback which can be used for actions such as fetching full documentation.
+     */
+    resolve?: (id: string) => void;
 
     /**
      * Collection of completion items.
@@ -561,12 +566,6 @@ export namespace CompletionHandler {
      * about this item, like type or symbol information.
      */
     documentation?: string;
-
-    /**
-     * TODO: This is not compatiable with PartialJSONObject
-     * Callback which can be used for actions such as fetching full documentation.
-     */
-    // resolve?: () => void;
 
     /**
      * A number used to help sort a set of completion items.

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -443,10 +443,20 @@ export class CompletionHandler implements IDisposable {
         };
         items.push(completionItem);
       });
-      model.isLegacy = true;
-      items = this._dedupe(items);
-      model.setItems({ isIncomplete: false, items });
+    } else {
+      // Fallback to matches if types is undefined
+      const matches = reply.matches;
+      matches.forEach((match: string) => {
+        let completionItem: CompletionHandler.ICompletionItem = {
+          label: match,
+          range: { start: reply.start, end: reply.end }
+        };
+        items.push(completionItem);
+      });
     }
+    model.isLegacy = true;
+    items = this._dedupe(items);
+    model.setItems({ isIncomplete: false, items });
   }
 
   /**

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -414,6 +414,7 @@ export class CompletionHandler implements IDisposable {
         matches.push(match);
         let item: CompletionHandler.ICompletionItem = {
           label: match,
+          type: 'kite',
           range: { start: reply.start, end: reply.end },
           icon: '',
           resolve: () => {}

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -523,7 +523,7 @@ export namespace CompletionHandler {
     /**
      * Callback which can be used for actions such as fetching full documentation.
      */
-    resolve?: (id: string) => void;
+    resolve?: (item: ICompletionItem) => void;
 
     /**
      * Collection of completion items.

--- a/packages/completer/src/handler.ts
+++ b/packages/completer/src/handler.ts
@@ -477,6 +477,29 @@ export namespace CompletionHandler {
     connector: IDataConnector<IReply, void, IRequest>;
   }
 
+  export interface ICompletionItems {
+    isIncomplete: boolean;
+    items: ReadonlyArray<ICompletionItem>;
+  }
+
+  export interface ICompletionItem {
+    label: string;
+    insertText?: string;
+    range: IRange;
+    type?: string;
+    icon: string;
+    documentation?: string;
+    resolve(): void;
+    filterText?: string;
+    deprecated?: boolean;
+    data?: any;
+  }
+
+  export interface IRange {
+    start: number;
+    end: number;
+  }
+
   /**
    * A reply to a completion request.
    */

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -165,7 +165,6 @@ export class CompleterModel implements Completer.IModel {
    */
   items(): CompletionHandler.ICompletionItems {
     this._markup();
-    console.log('isLegacy:', this.isLegacy);
     if (this.isLegacy) {
       this._dedupe();
       this._sort();

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -5,13 +5,13 @@ import {
   IIterator,
   IterableOrArrayLike,
   iter,
-  map,
+  // map,
   toArray
 } from '@lumino/algorithm';
 
 import { JSONExt } from '@lumino/coreutils';
 
-import { StringExt } from '@lumino/algorithm';
+// import { StringExt } from '@lumino/algorithm';
 
 import { ISignal, Signal } from '@lumino/signaling';
 
@@ -172,7 +172,11 @@ export class CompleterModel implements Completer.IModel {
    * This is a read-only property.
    */
   items(): CompletionHandler.ICompletionItems {
-    return { isIncomplete: false, items: [] };
+    return this._items;
+  }
+
+  setItems(items: CompletionHandler.ICompletionItems): void {
+    this._items = items;
   }
 
   /**
@@ -358,29 +362,29 @@ export class CompleterModel implements Completer.IModel {
   /**
    * Apply the query to the complete options list to return the matching subset.
    */
-  private _filter(): IIterator<Completer.IItem> {
-    let options = this._options || [];
-    let query = this._query;
-    if (!query) {
-      return map(options, option => ({ raw: option, text: option }));
-    }
-    let results: Private.IMatch[] = [];
-    for (let option of options) {
-      let match = StringExt.matchSumOfSquares(option, query);
-      if (match) {
-        let marked = StringExt.highlight(option, match.indices, Private.mark);
-        results.push({
-          raw: option,
-          score: match.score,
-          text: marked.join('')
-        });
-      }
-    }
-    return map(results.sort(Private.scoreCmp), result => ({
-      text: result.text,
-      raw: result.raw
-    }));
-  }
+  // private _filter(): IIterator<Completer.IItem> {
+  //   let options = this._options || [];
+  //   let query = this._query;
+  //   if (!query) {
+  //     return map(options, option => ({ raw: option, text: option }));
+  //   }
+  //   let results: Private.IMatch[] = [];
+  //   for (let option of options) {
+  //     let match = StringExt.matchSumOfSquares(option, query);
+  //     if (match) {
+  //       let marked = StringExt.highlight(option, match.indices, Private.mark);
+  //       results.push({
+  //         raw: option,
+  //         score: match.score,
+  //         text: marked.join('')
+  //       });
+  //     }
+  //   }
+  //   return map(results.sort(Private.scoreCmp), result => ({
+  //     text: result.text,
+  //     raw: result.raw
+  //   }));
+  // }
 
   /**
    * Reset the state of the model.
@@ -399,6 +403,7 @@ export class CompleterModel implements Completer.IModel {
   private _current: Completer.ITextState | null = null;
   private _cursor: Completer.ICursorSpan | null = null;
   private _isDisposed = false;
+  private _items: CompletionHandler.ICompletionItems;
   private _options: string[] = [];
   private _original: Completer.ITextState | null = null;
   private _query = '';

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -180,7 +180,7 @@ export class CompleterModel implements Completer.IModel {
    * new types to KNOWN_TYPES.
    */
   setItems(newValue: CompletionHandler.ICompletionItems): void {
-    if (JSONExt.deepEqual(newValue, this._items)) {
+    if (JSONExt.deepEqual(newValue.items, this._items.items)) {
       return;
     }
     const items = newValue.items;

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -165,6 +165,7 @@ export class CompleterModel implements Completer.IModel {
    */
   items(): CompletionHandler.ICompletionItems {
     this._markup();
+    console.log('isLegacy:', this.isLegacy);
     if (this.isLegacy) {
       this._dedupe();
       this._sort();
@@ -504,12 +505,16 @@ namespace Private {
   export function findOrderedTypes(
     items: CompletionHandler.ICompletionItem[]
   ): string[] {
-    const newTypes: string[] = [];
+    const newTypeSet = new Set<string>();
     items.forEach(item => {
-      if (item.type && !KNOWN_TYPES.includes(item.type)) {
-        newTypes.concat(item.type);
+      if (
+        (item.type && !KNOWN_TYPES.includes(item.type)) ||
+        !newTypeSet.has(item.type!)
+      ) {
+        newTypeSet.add(item.type!);
       }
     });
+    const newTypes = Array.from(newTypeSet);
     newTypes.sort((a, b) => a.localeCompare(b));
     return KNOWN_TYPES.concat(newTypes);
   }

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -463,7 +463,7 @@ namespace Private {
     b: CompletionHandler.ICompletionItem
   ): number {
     if (a.score && b.score) {
-      let delta = a.score - b.score;
+      let delta = (a.score as number) - (b.score as number);
       if (delta !== 0) {
         return delta;
       }

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -398,6 +398,7 @@ export class CompleterModel implements Completer.IModel {
     this._subsetMatch = false;
     this._typeMap = {};
     this._orderedTypes = [];
+    this._items = { isIncomplete: false, items: [] };
   }
 
   private _current: Completer.ITextState | null = null;

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -441,14 +441,6 @@ namespace Private {
   const KNOWN_TYPES = ['function', 'instance', 'class', 'module', 'keyword'];
 
   /**
-   * The map of known type annotations of completer matches.
-   */
-  const KNOWN_MAP = KNOWN_TYPES.reduce((acc, type) => {
-    acc[type] = null;
-    return acc;
-  }, {} as Completer.TypeMap);
-
-  /**
    * A filtered completion menu matching result.
    */
   export interface IMatch {
@@ -512,18 +504,13 @@ namespace Private {
   export function findOrderedTypes(
     items: CompletionHandler.ICompletionItem[]
   ): string[] {
+    const newTypes: string[] = [];
     items.forEach(item => {
       if (item.type && !KNOWN_TYPES.includes(item.type)) {
         newTypes.concat(item.type);
       }
     });
-    const newTypes = items
-      .map(item => item.type)
-      .filter(
-        (value: string | undefined): value is string =>
-          !!value && !(value in KNOWN_MAP)
-      )
-      .sort((a, b) => a.localeCompare(b));
+    newTypes.sort((a, b) => a.localeCompare(b));
     return KNOWN_TYPES.concat(newTypes);
   }
 }

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -16,7 +16,7 @@ import { StringExt } from '@lumino/algorithm';
 import { ISignal, Signal } from '@lumino/signaling';
 
 import { Completer } from './widget';
-
+import { CompletionHandler } from './handler';
 /**
  * An implementation of a completer model.
  */
@@ -171,8 +171,8 @@ export class CompleterModel implements Completer.IModel {
    * #### Notes
    * This is a read-only property.
    */
-  items(): IIterator<Completer.IItem> {
-    return this._filter();
+  items(): CompletionHandler.ICompletionItems {
+    return { isIncomplete: false, items: [] };
   }
 
   /**

--- a/packages/completer/src/model.ts
+++ b/packages/completer/src/model.ts
@@ -378,9 +378,8 @@ export class CompleterModel implements Completer.IModel {
    * Sort ICompletionItem based on its score attribute.
    */
   private _sort(): void {
-    let items = (this._items && this._items.items) || [];
+    const items = this._items.items;
     items.sort(Private.scoreCmp);
-    this._items.items = items;
   }
 
   /**

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -7,7 +7,7 @@ import { CodeEditor } from '@jupyterlab/codeeditor';
 
 import { IIterator, IterableOrArrayLike, toArray } from '@lumino/algorithm';
 
-import { JSONObject, JSONExt } from '@lumino/coreutils';
+import { JSONObject } from '@lumino/coreutils';
 
 import { IDisposable } from '@lumino/disposable';
 
@@ -49,7 +49,7 @@ const USE_CAPTURE = true;
  * The number of colors defined for the completer type annotations.
  * These are listed in completer/style/index.css#102-152.
  */
-const N_COLORS = 10;
+// const N_COLORS = 10;
 
 /**
  * A widget that enables text completion.
@@ -256,7 +256,7 @@ export class Completer extends Widget {
 
     // Compute an ordered list of all the types in the typeMap, this is computed
     // once by the model each time new data arrives for efficiency.
-    let orderedTypes = model.orderedTypes();
+    // let orderedTypes = model.orderedTypes();
 
     // Populate the completer items.
     for (let item of items) {
@@ -607,6 +607,8 @@ export namespace Completer {
      */
     // items(): IIterator<IItem>;
     items(): CompletionHandler.ICompletionItems;
+
+    setItems(items: CompletionHandler.ICompletionItems): void;
 
     /**
      * Get the unfiltered options in a completer menu.

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -226,7 +226,7 @@ export class Completer extends Widget {
       return;
     }
 
-    let items = toArray(model.items());
+    let items = model.items().items;
 
     // If there are no items, reset and bail.
     if (!items || !items.length) {
@@ -260,11 +260,7 @@ export class Completer extends Widget {
 
     // Populate the completer items.
     for (let item of items) {
-      let li = this._renderer.createItemNode(
-        item!,
-        model.typeMap(),
-        orderedTypes
-      );
+      let li = this._renderer.createItemNode(item);
       node.appendChild(li);
     }
 
@@ -609,7 +605,8 @@ export namespace Completer {
     /**
      * Get the of visible items in the completer menu.
      */
-    items(): IIterator<IItem>;
+    // items(): IIterator<IItem>;
+    items(): CompletionHandler.ICompletionItems;
 
     /**
      * Get the unfiltered options in a completer menu.
@@ -712,22 +709,22 @@ export namespace Completer {
    * A renderer for completer widget nodes.
    */
   export interface IRenderer {
-    _createItemNode(item: CompletionHandler.ICompletionItem): HTMLLIElement;
+    createItemNode(item: CompletionHandler.ICompletionItem): HTMLLIElement;
     /**
      * Create an item node (an `li` element) for a text completer menu.
      */
-    createItemNode(
-      item: IItem,
-      typeMap: TypeMap,
-      orderedTypes: string[]
-    ): HTMLLIElement;
+    // createItemNode(
+    //   item: IItem,
+    //   typeMap: TypeMap,
+    //   orderedTypes: string[]
+    // ): HTMLLIElement;
   }
 
   /**
    * The default implementation of an `IRenderer`.
    */
   export class Renderer implements IRenderer {
-    _createItemNode(item: CompletionHandler.ICompletionItem): HTMLLIElement {
+    createItemNode(item: CompletionHandler.ICompletionItem): HTMLLIElement {
       let li = document.createElement('li');
       li.className = ITEM_CLASS;
       // Set the raw, un-marked up value as a data attribute.
@@ -770,43 +767,43 @@ export namespace Completer {
     /**
      * Create an item node for a text completer menu.
      */
-    createItemNode(
-      item: IItem,
-      typeMap: TypeMap,
-      orderedTypes: string[]
-    ): HTMLLIElement {
-      let li = document.createElement('li');
-      li.className = ITEM_CLASS;
-      // Set the raw, un-marked up value as a data attribute.
-      li.setAttribute('data-value', item.raw);
+    // createItemNode(
+    //   item: IItem,
+    //   typeMap: TypeMap,
+    //   orderedTypes: string[]
+    // ): HTMLLIElement {
+    //   let li = document.createElement('li');
+    //   li.className = ITEM_CLASS;
+    //   // Set the raw, un-marked up value as a data attribute.
+    //   li.setAttribute('data-value', item.raw);
 
-      let matchNode = document.createElement('code');
-      matchNode.className = 'jp-Completer-match';
-      // Use innerHTML because search results include <mark> tags.
-      matchNode.innerHTML = defaultSanitizer.sanitize(item.text, {
-        allowedTags: ['mark']
-      });
+    //   let matchNode = document.createElement('code');
+    //   matchNode.className = 'jp-Completer-match';
+    //   // Use innerHTML because search results include <mark> tags.
+    //   matchNode.innerHTML = defaultSanitizer.sanitize(item.text, {
+    //     allowedTags: ['mark']
+    //   });
 
-      // If there are types provided add those.
-      if (!JSONExt.deepEqual(typeMap, {})) {
-        let typeNode = document.createElement('span');
-        let type = typeMap[item.raw] || '';
-        typeNode.textContent = (type[0] || '').toLowerCase();
-        let colorIndex = (orderedTypes.indexOf(type) % N_COLORS) + 1;
-        typeNode.className = 'jp-Completer-type';
-        typeNode.setAttribute(`data-color-index`, colorIndex.toString());
-        li.title = type;
-        let typeExtendedNode = document.createElement('code');
-        typeExtendedNode.className = 'jp-Completer-typeExtended';
-        typeExtendedNode.textContent = type.toLocaleLowerCase();
-        li.appendChild(typeNode);
-        li.appendChild(matchNode);
-        li.appendChild(typeExtendedNode);
-      } else {
-        li.appendChild(matchNode);
-      }
-      return li;
-    }
+    //   // If there are types provided add those.
+    //   if (!JSONExt.deepEqual(typeMap, {})) {
+    //     let typeNode = document.createElement('span');
+    //     let type = typeMap[item.raw] || '';
+    //     typeNode.textContent = (type[0] || '').toLowerCase();
+    //     let colorIndex = (orderedTypes.indexOf(type) % N_COLORS) + 1;
+    //     typeNode.className = 'jp-Completer-type';
+    //     typeNode.setAttribute(`data-color-index`, colorIndex.toString());
+    //     li.title = type;
+    //     let typeExtendedNode = document.createElement('code');
+    //     typeExtendedNode.className = 'jp-Completer-typeExtended';
+    //     typeExtendedNode.textContent = type.toLocaleLowerCase();
+    //     li.appendChild(typeNode);
+    //     li.appendChild(matchNode);
+    //     li.appendChild(typeExtendedNode);
+    //   } else {
+    //     li.appendChild(matchNode);
+    //   }
+    //   return li;
+    // }
   }
 
   /**

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -226,6 +226,7 @@ export class Completer extends Widget {
       return;
     }
 
+    console.log(model.items());
     let items = model.items().items;
 
     // If there are no items, reset and bail.

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -717,9 +717,7 @@ export namespace Completer {
       if (item.type) {
         let typeNode = document.createElement('span');
         let type = item.type;
-        typeNode.textContent = typeNode.textContent = (
-          type[0] || ''
-        ).toLowerCase();
+        typeNode.textContent = (type[0] || '').toLowerCase();
         let colorIndex = (orderedTypes.indexOf(type) % N_COLORS) + 1;
         typeNode.className = 'jp-Completer-type';
         typeNode.setAttribute(`data-color-index`, colorIndex.toString());

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -5,8 +5,6 @@ import { HoverBox, defaultSanitizer } from '@jupyterlab/apputils';
 
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
-// import { IIterator, IterableOrArrayLike, toArray } from '@lumino/algorithm';
-
 import { JSONObject } from '@lumino/coreutils';
 
 import { IDisposable } from '@lumino/disposable';
@@ -243,12 +241,6 @@ export class Completer extends Widget {
     // We don't test the filtered `items`, as that
     // is too aggressive of completer behavior, it can
     // lead to double typing of an option.
-    // const options = toArray(model.options());
-    // if (options.length === 1) {
-    //   this._selected.emit(options[0]);
-    //   this.reset();
-    //   return;
-    // }
     if (items.length === 1) {
       this._selected.emit(items[0].insertText || items[0].label);
       this.reset();
@@ -353,14 +345,14 @@ export class Completer extends Widget {
           return;
         }
         let populated = this._populateSubset();
-        // If there is a common subset in the options,
+        // If there is a common subset in the completions list,
         // then emit a completion signal with that subset.
         if (model.query) {
           model.subsetMatch = true;
           this._selected.emit(model.query);
           model.subsetMatch = false;
         }
-        // If the query changed, update rendering of the options.
+        // If the query changed, update rendering of the completions list.
         if (populated) {
           this.update();
         }
@@ -586,7 +578,7 @@ export namespace Completer {
     current: ITextState | null;
 
     /**
-     * The cursor details that the API has used to return matching options.
+     * The cursor details that the API has used to return matching completions.
      */
     cursor: ICursorSpan | null;
 
@@ -611,17 +603,14 @@ export namespace Completer {
     isLegacy: boolean;
 
     /**
-     * Get the of visible items in the completer menu.
+     * Get the list of visible items in the completer menu.
      */
-    // items(): IIterator<IItem>;
     items(): CompletionHandler.ICompletionItems;
 
-    setItems(items: CompletionHandler.ICompletionItems): void;
-
     /**
-     * Get the unfiltered options in a completer menu.
+     * Set the list of visible items in the completer menu.
      */
-    // options(): IIterator<string>;
+    setItems(items: CompletionHandler.ICompletionItems): void;
 
     /**
      * The map from identifiers (`a.b`) to their types (function, module, class,
@@ -633,14 +622,6 @@ export namespace Completer {
      * An ordered list of types used for visual encoding.
      */
     orderedTypes(): string[];
-
-    /**
-     * Set the available options in the completer menu.
-     */
-    // setOptions(
-    //   options: IterableOrArrayLike<string>,
-    //   typeMap?: JSONObject
-    // ): void;
 
     /**
      * Handle a cursor change.
@@ -686,21 +667,6 @@ export namespace Completer {
   }
 
   /**
-   * A completer menu item.
-   */
-  export interface IItem {
-    /**
-     * The highlighted, marked up text of a visible completer item.
-     */
-    text: string;
-
-    /**
-     * The raw text of a visible completer item.
-     */
-    raw: string;
-  }
-
-  /**
    * A cursor span.
    */
   export interface ICursorSpan extends JSONObject {
@@ -719,18 +685,13 @@ export namespace Completer {
    * A renderer for completer widget nodes.
    */
   export interface IRenderer {
+    /**
+     * Create an item node (an `li` element) for a text completer menu.
+     */
     createItemNode(
       item: CompletionHandler.ICompletionItem,
       orderedTypes: string[]
     ): HTMLLIElement;
-    /**
-     * Create an item node (an `li` element) for a text completer menu.
-     */
-    // createItemNode(
-    //   item: IItem,
-    //   typeMap: TypeMap,
-    //   orderedTypes: string[]
-    // ): HTMLLIElement;
   }
 
   /**
@@ -772,50 +733,8 @@ export namespace Completer {
       } else {
         li.appendChild(matchNode);
       }
-      // Add icons, docs, etc...
       return li;
     }
-
-    /**
-     * Create an item node for a text completer menu.
-     */
-    // createItemNode(
-    //   item: IItem,
-    //   typeMap: TypeMap,
-    //   orderedTypes: string[]
-    // ): HTMLLIElement {
-    //   let li = document.createElement('li');
-    //   li.className = ITEM_CLASS;
-    //   // Set the raw, un-marked up value as a data attribute.
-    //   li.setAttribute('data-value', item.raw);
-
-    //   let matchNode = document.createElement('code');
-    //   matchNode.className = 'jp-Completer-match';
-    //   // Use innerHTML because search results include <mark> tags.
-    //   matchNode.innerHTML = defaultSanitizer.sanitize(item.text, {
-    //     allowedTags: ['mark']
-    //   });
-
-    //   // If there are types provided add those.
-    //   if (!JSONExt.deepEqual(typeMap, {})) {
-    //     let typeNode = document.createElement('span');
-    //     let type = typeMap[item.raw] || '';
-    //     typeNode.textContent = (type[0] || '').toLowerCase();
-    //     let colorIndex = (orderedTypes.indexOf(type) % N_COLORS) + 1;
-    //     typeNode.className = 'jp-Completer-type';
-    //     typeNode.setAttribute(`data-color-index`, colorIndex.toString());
-    //     li.title = type;
-    //     let typeExtendedNode = document.createElement('code');
-    //     typeExtendedNode.className = 'jp-Completer-typeExtended';
-    //     typeExtendedNode.textContent = type.toLocaleLowerCase();
-    //     li.appendChild(typeNode);
-    //     li.appendChild(matchNode);
-    //     li.appendChild(typeExtendedNode);
-    //   } else {
-    //     li.appendChild(matchNode);
-    //   }
-    //   return li;
-    // }
   }
 
   /**

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -281,7 +281,6 @@ export class Completer extends Widget {
         return;
       }
     }
-
     if (this.isHidden) {
       this.show();
       this._setGeometry();
@@ -462,7 +461,6 @@ export class Completer extends Widget {
     const items = this.node.querySelectorAll(`.${ITEM_CLASS}`);
     const subset = Private.commonSubset(Private.itemValues(items));
     const { query } = model;
-
     // If a common subset exists and it is not the current query, highlight it.
     if (subset && subset !== query && subset.indexOf(query) === 0) {
       model.query = subset;
@@ -608,6 +606,11 @@ export namespace Completer {
     query: string;
 
     /**
+     * A flag that is true when completions are generated from the legacy completer API.
+     */
+    isLegacy: boolean;
+
+    /**
      * Get the of visible items in the completer menu.
      */
     // items(): IIterator<IItem>;
@@ -741,13 +744,7 @@ export namespace Completer {
       let li = document.createElement('li');
       li.className = ITEM_CLASS;
       // Set the raw, un-marked up value as a data attribute.
-      let dataValue: string;
-      if (item.insertText) {
-        dataValue = item.insertText;
-      } else {
-        dataValue = item.label;
-      }
-      li.setAttribute('data-value', dataValue);
+      li.setAttribute('data-value', item.insertText || item.label);
 
       let matchNode = document.createElement('code');
       matchNode.className = 'jp-Completer-match';

--- a/packages/completer/src/widget.ts
+++ b/packages/completer/src/widget.ts
@@ -18,6 +18,7 @@ import { Message } from '@lumino/messaging';
 import { ISignal, Signal } from '@lumino/signaling';
 
 import { Widget } from '@lumino/widgets';
+import { CompletionHandler } from './handler';
 
 /**
  * The class name added to completer menu items.
@@ -711,6 +712,7 @@ export namespace Completer {
    * A renderer for completer widget nodes.
    */
   export interface IRenderer {
+    _createItemNode(item: CompletionHandler.ICompletionItem): HTMLLIElement;
     /**
      * Create an item node (an `li` element) for a text completer menu.
      */
@@ -725,6 +727,46 @@ export namespace Completer {
    * The default implementation of an `IRenderer`.
    */
   export class Renderer implements IRenderer {
+    _createItemNode(item: CompletionHandler.ICompletionItem): HTMLLIElement {
+      let li = document.createElement('li');
+      li.className = ITEM_CLASS;
+      // Set the raw, un-marked up value as a data attribute.
+      let dataValue: string;
+      if (item.insertText) {
+        dataValue = item.insertText;
+      } else {
+        dataValue = item.label;
+      }
+      li.setAttribute('data-value', dataValue);
+
+      let matchNode = document.createElement('code');
+      matchNode.className = 'jp-Completer-match';
+      // Use innerHTML because search results include <mark> tags.
+      matchNode.innerHTML = defaultSanitizer.sanitize(item.label, {
+        allowedTags: ['mark']
+      });
+
+      if (item.type) {
+        let typeNode = document.createElement('span');
+        let type = item.type;
+        typeNode.textContent = type.toLowerCase();
+        let colorIndex = 1; // TODO: Implement this properly
+        typeNode.className = 'jp-Completer-type';
+        typeNode.setAttribute(`data-color-index`, colorIndex.toString());
+        li.title = type;
+        let typeExtendedNode = document.createElement('code');
+        typeExtendedNode.className = 'jp-Completer-typeExtended';
+        typeExtendedNode.textContent = type.toLocaleLowerCase();
+        li.appendChild(typeNode);
+        li.appendChild(matchNode);
+        li.appendChild(typeExtendedNode);
+      } else {
+        li.appendChild(matchNode);
+      }
+      // Add icons, docs, etc...
+      return li;
+    }
+
     /**
      * Create an item node for a text completer menu.
      */

--- a/packages/completer/tsconfig.json
+++ b/packages/completer/tsconfig.json
@@ -16,6 +16,9 @@
       "path": "../coreutils"
     },
     {
+      "path": "../observables"
+    },
+    {
       "path": "../services"
     },
     {

--- a/packages/completer/tsconfig.json
+++ b/packages/completer/tsconfig.json
@@ -16,9 +16,6 @@
       "path": "../coreutils"
     },
     {
-      "path": "../observables"
-    },
-    {
       "path": "../services"
     },
     {

--- a/tests/test-completer/package.json
+++ b/tests/test-completer/package.json
@@ -17,8 +17,6 @@
     "@jupyterlab/codemirror": "^2.0.2",
     "@jupyterlab/completer": "^2.0.2",
     "@jupyterlab/testutils": "^2.0.2",
-    "@lumino/algorithm": "^1.2.3",
-    "@lumino/coreutils": "^1.4.2",
     "@lumino/messaging": "^1.3.3",
     "@lumino/widgets": "^1.11.1",
     "chai": "^4.2.0",

--- a/tests/test-completer/src/model.spec.ts
+++ b/tests/test-completer/src/model.spec.ts
@@ -3,10 +3,6 @@
 
 import { expect } from 'chai';
 
-// import { toArray } from '@lumino/algorithm';
-
-// import { JSONExt } from '@lumino/coreutils';
-
 import { CodeEditor } from '@jupyterlab/codeeditor';
 
 import {


### PR DESCRIPTION
## References
jupyterlab/jupyterlab#7044

See https://github.com/jupyterlab/jupyterlab/issues/7044#issuecomment-594249225 for high level architecture (may be a little out of date)

## Code changes

#### Handler
* Added `ICompletionItems` and `ICompletionItem` interfaces to encapsulate completions
* Added `ICompletionItems` as an optional property to preexisting `IReply` interface to keep backwards compatibility with preexisting connectors
* In the response handler, if the `ICompletionItems` property `items` is in the reply, send to the model right away
* Otherwise, look for legacy `types` property and transform reply into `ICompletionItems` objects
* Move de-duping of completions into separate function `_dedupe()`

####  Model
* Migrate getters and setters for `options` -> `items`
* Split up `_filter()` into its individual parts `_markup()` and `_sort()`
  * Add boolean `isLegacy` so preexisting completions use  default `_sort`
* Updated `findOrderedTypes` to add new types into a set, before sorting as an array to append to `KNOWN_TYPES`

#### Widget:
* Incorporate ICompletionItems in `onUpdateRequest` and `createItemNode`
* Removed unused interface `IItem`

## User-facing changes
N/A

## Backwards-incompatible changes
N/A
